### PR TITLE
[JENKINS-72893] A solution for JSONException thrown after saving system settings

### DIFF
--- a/src/main/java/io/jenkins/plugins/twofactor/jenkins/MoGlobalConfig.java
+++ b/src/main/java/io/jenkins/plugins/twofactor/jenkins/MoGlobalConfig.java
@@ -141,6 +141,10 @@ public class MoGlobalConfig extends GlobalConfiguration {
 
   @Override
   public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+    if (!formData.has("formPage")) {
+      return super.configure(req, formData);
+    }
+
     String formPage = formData.getString("formPage");
     switch (formPage) {
       case "basicConfig":


### PR DESCRIPTION
See [https://issues.jenkins.io/browse/JENKINS-72893](url)

With MFA plugin enabled, a JSONException was getting thrown when user is trying to save global config,. This is because io.jenkins.plugins.twofactor.jenkins.MoGlobalConfig#configure method is getting called, where it is trying to access the "formPage" JSON property from the request form data. Now the property is present for that plugin specific config request (i.e /manage/tfaGlobalConfig/) but not in global config setting request (i.e. /manage/configure).

Now I assume that property should not be there in global config request but I'm not sure about it and need clarification from someone else. If it's true then I've added a conditional check that makes the method return prematurely if no such property is found in the form data.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
